### PR TITLE
Remove To prefix from type conversion methods

### DIFF
--- a/either.go
+++ b/either.go
@@ -62,7 +62,7 @@ func (e Either[L, R]) RequireRight() R {
 	return e.right
 }
 
-// ToTuple both values regardless of the type.
-func (e Either[L, R]) ToTuple() (L, R) {
+// Tuple returns both values regardless of the type.
+func (e Either[L, R]) Tuple() (L, R) {
 	return e.left, e.right
 }

--- a/maybe.go
+++ b/maybe.go
@@ -19,16 +19,16 @@ func NewMaybe[T any](hasValue bool, value T) Maybe[T] {
 
 // IsEmpty checks if this is a Nothing/Empty Maybe.
 func (m Maybe[T]) IsEmpty() bool {
-	return m.ToEither().IsRight()
+	return m.Either().IsRight()
 }
 
 // HasValue checks if the maybe has something in it.
 func (m Maybe[T]) HasValue() bool {
-	return m.ToEither().IsLeft()
+	return m.Either().IsLeft()
 }
 
-// ToEither converts into a Maybe.
-func (m Maybe[T]) ToEither() Either[T, Nothing] {
+// Either converts into a Maybe.
+func (m Maybe[T]) Either() Either[T, Nothing] {
 	return Either[T, Nothing](m)
 }
 

--- a/promise/constructors.go
+++ b/promise/constructors.go
@@ -37,7 +37,7 @@ func FromValue[T any](value T) fun.Promise[T] {
 // FromResult returns a promise that fulfills with a static result.
 func FromResult[T any](value fun.Result[T]) fun.Promise[T] {
 	return New(func(ctx context.Context) (T, error) {
-		return value.ToTuple()
+		return value.Tuple()
 	})
 }
 

--- a/promise/implementation.go
+++ b/promise/implementation.go
@@ -99,16 +99,16 @@ func (p *promise[T]) RequireValue() T {
 }
 
 // ToEither implements Result.
-func (p *promise[T]) ToEither() fun.Either[T, error] {
-	return p.Result().ToEither()
+func (p *promise[T]) Either() fun.Either[T, error] {
+	return p.Result().Either()
 }
 
 // ToMaybe implements Result.
-func (p *promise[T]) ToMaybe() fun.Maybe[T] {
-	return p.Result().ToMaybe()
+func (p *promise[T]) Maybe() fun.Maybe[T] {
+	return p.Result().Maybe()
 }
 
 // ToTuple implements Result.
-func (p *promise[T]) ToTuple() (T, error) {
-	return p.Result().ToTuple()
+func (p *promise[T]) Tuple() (T, error) {
+	return p.Result().Tuple()
 }

--- a/result.go
+++ b/result.go
@@ -6,7 +6,7 @@ type Result[T any] interface {
 	IsFailure() bool
 	IsSuccess() bool
 	RequireValue() T
-	ToEither() Either[T, error]
-	ToMaybe() Maybe[T]
-	ToTuple() (T, error)
+	Either() Either[T, error]
+	Maybe() Maybe[T]
+	Tuple() (T, error)
 }

--- a/result/implementation.go
+++ b/result/implementation.go
@@ -10,39 +10,39 @@ var _ fun.Result[int] = result[int]{}
 
 // Error gets the Result error.
 func (r result[T]) Error() error {
-	return r.ToEither().Right()
+	return r.Either().Right()
 }
 
 // IsFailure checks if the result is a failure.
 func (r result[T]) IsFailure() bool {
-	return r.ToEither().IsRight()
+	return r.Either().IsRight()
 }
 
 // IsSuccess check if the Result is successful.
 func (r result[T]) IsSuccess() bool {
-	return r.ToEither().IsLeft()
+	return r.Either().IsLeft()
 }
 
 // RequireValue get's the result value or panics.
 func (r result[T]) RequireValue() T {
 	if r.IsSuccess() {
-		return r.ToEither().Left()
+		return r.Either().Left()
 	}
 
 	panic(r.Error())
 }
 
 // Get extract both value and error.
-func (r result[T]) ToTuple() (T, error) {
-	return r.ToEither().ToTuple()
+func (r result[T]) Tuple() (T, error) {
+	return r.Either().Tuple()
 }
 
 // ToEither converts a result to an Either.
-func (r result[T]) ToEither() fun.Either[T, error] {
+func (r result[T]) Either() fun.Either[T, error] {
 	return fun.Either[T, error](r)
 }
 
 // ToMaybe converts a result to a Maybe.
-func (r result[T]) ToMaybe() fun.Maybe[T] {
-	return fun.NewMaybe(r.IsSuccess(), r.ToEither().Left())
+func (r result[T]) Maybe() fun.Maybe[T] {
+	return fun.NewMaybe(r.IsSuccess(), r.Either().Left())
 }

--- a/result/stepping.go
+++ b/result/stepping.go
@@ -16,7 +16,7 @@ func Stepper[From, To any](f func(From) To) StepFun[From, To] {
 func Step[From, To any](
 	from fun.Result[From],
 	step StepFun[From, To]) fun.Result[To] {
-	val, err := from.ToTuple()
+	val, err := from.Tuple()
 	if err != nil {
 		return Failure[To](err)
 	}

--- a/tests/either_test.go
+++ b/tests/either_test.go
@@ -16,7 +16,7 @@ func TestLeft(t *testing.T) {
 	assert.Equal(t, 3, e.Left())
 	assert.Equal(t, 3, e.RequireLeft())
 
-	v, _ := e.ToTuple()
+	v, _ := e.Tuple()
 	assert.Equal(t, 3, v)
 
 	assert.Panics(t, func() {
@@ -32,7 +32,7 @@ func TestRight(t *testing.T) {
 	assert.Equal(t, "hello", e.Right())
 	assert.Equal(t, "hello", e.RequireRight())
 
-	_, v := e.ToTuple()
+	_, v := e.Tuple()
 	assert.Equal(t, "hello", v)
 
 	assert.Panics(t, func() {

--- a/tests/maybe_test.go
+++ b/tests/maybe_test.go
@@ -16,7 +16,7 @@ func TestJust(t *testing.T) {
 	assert.True(t, m.HasValue())
 	assert.False(t, m.IsEmpty())
 	assert.Equal(t, 5, m.RequireValue())
-	assert.Equal(t, either.Left[fun.Nothing](5), m.ToEither())
+	assert.Equal(t, either.Left[fun.Nothing](5), m.Either())
 }
 
 func TestMaybeEmpty(t *testing.T) {
@@ -28,5 +28,5 @@ func TestMaybeEmpty(t *testing.T) {
 		m.RequireValue()
 	})
 
-	assert.Equal(t, either.Right[int](fun.Nothing{}), m.ToEither())
+	assert.Equal(t, either.Right[int](fun.Nothing{}), m.Either())
 }

--- a/tests/promise_test.go
+++ b/tests/promise_test.go
@@ -18,8 +18,8 @@ func TestPromiseFromValue(t *testing.T) {
 	p := promise.FromValue(3)
 
 	assert.Equal(t, result.Success(3), p.Result())
-	assert.Equal(t, maybe.Just(3), p.ToMaybe())
-	assert.Equal(t, either.Left[error](3), p.ToEither())
+	assert.Equal(t, maybe.Just(3), p.Maybe())
+	assert.Equal(t, either.Left[error](3), p.Either())
 	assert.Equal(t, 3, p.RequireValue())
 	assert.True(t, p.IsSuccess())
 	assert.False(t, p.IsFailure())
@@ -29,7 +29,7 @@ func TestPromiseFromError(t *testing.T) {
 	p := promise.FromError[string](assert.AnError)
 
 	assert.Equal(t, result.Failure[string](assert.AnError), p.Result())
-	assert.Equal(t, either.Right[string](assert.AnError), p.ToEither())
+	assert.Equal(t, either.Right[string](assert.AnError), p.Either())
 	assert.False(t, p.IsSuccess())
 	assert.True(t, p.IsFailure())
 }
@@ -95,7 +95,7 @@ func TestPromiseCancelRace(t *testing.T) {
 	for i < 100 {
 		p := promise.FromValue(i)
 		go p.Cancel()
-		val, err := p.ToTuple()
+		val, err := p.Tuple()
 		if err == nil {
 			assert.Equal(t, i, val)
 		}

--- a/tests/result_test.go
+++ b/tests/result_test.go
@@ -17,10 +17,10 @@ func TestSuccess(t *testing.T) {
 	assert.True(t, r.IsSuccess())
 	assert.False(t, r.IsFailure())
 	assert.Equal(t, 5, r.RequireValue())
-	assert.Equal(t, either.Left[error](5), r.ToEither())
-	assert.Equal(t, maybe.Just(5), r.ToMaybe())
+	assert.Equal(t, either.Left[error](5), r.Either())
+	assert.Equal(t, maybe.Just(5), r.Maybe())
 
-	v, err := r.ToTuple()
+	v, err := r.Tuple()
 	assert.Equal(t, 5, v)
 	assert.Nil(t, err)
 }
@@ -34,10 +34,10 @@ func TestFailure(t *testing.T) {
 	assert.Panics(t, func() {
 		r.RequireValue()
 	})
-	assert.Equal(t, either.Right[int](assert.AnError), r.ToEither())
-	assert.Equal(t, maybe.Empty[int](), r.ToMaybe())
+	assert.Equal(t, either.Right[int](assert.AnError), r.Either())
+	assert.Equal(t, maybe.Empty[int](), r.Maybe())
 
-	_, err := r.ToTuple()
+	_, err := r.Tuple()
 	assert.Equal(t, assert.AnError, err)
 }
 


### PR DESCRIPTION
For the most part go doesn't prefixes type conversions with `To` so this should be more consistent/idiomatic.