### PR TITLE
Creating more builder chain helper functions

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -68,8 +68,8 @@ func WithOptions[T any](options []Option[T]) Option[T] {
 	}
 }
 
-// Fail just fails a builder chain with the specified error.
-func Fail[T any](err error) Option[T] {
+// WithError just fails a builder chain with the specified error.
+func WithError[T any](err error) Option[T] {
 	return func(*T) error {
 		return err
 	}
@@ -85,7 +85,7 @@ func FromFunction[T any](function func() Option[T]) Option[T] {
 // FromResult allows to derive options from a fun.Result value.
 func FromResult[R, T any](r fun.Result[R], then func(R) Option[T]) Option[T] {
 	if r.IsFailure() {
-		return Fail[T](r.Error())
+		return WithError[T](r.Error())
 	}
 
 	return then(r.RequireValue())

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -68,9 +68,25 @@ func WithOptions[T any](options []Option[T]) Option[T] {
 	}
 }
 
-// WithFunction allows to insert an arbitrary function within a build chain.
-func WithFunction[T any](function func() Option[T]) Option[T] {
+// Fail just fails a builder chain with the specified error.
+func Fail[T any](err error) Option[T] {
+	return func(*T) error {
+		return err
+	}
+}
+
+// FromFunction allows to derive options from an arbitrary function.
+func FromFunction[T any](function func() Option[T]) Option[T] {
 	return func(t *T) error {
 		return function()(t)
 	}
+}
+
+// FromResult allows to derive options from a fun.Result value.
+func FromResult[R, T any](r fun.Result[R], then func(R) Option[T]) Option[T] {
+	if r.IsFailure() {
+		return Fail[T](r.Error())
+	}
+
+	return then(r.RequireValue())
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -67,3 +67,10 @@ func WithOptions[T any](options []Option[T]) Option[T] {
 		return nil
 	}
 }
+
+// WithFunction allows to insert an arbitrary function within a build chain.
+func WithFunction[T any](function func() Option[T]) Option[T] {
+	return func(t *T) error {
+		return function()(t)
+	}
+}

--- a/tests/builder_test.go
+++ b/tests/builder_test.go
@@ -91,3 +91,24 @@ func TestWithOptions(t *testing.T) {
 	assert.True(t, o.IsSuccess())
 	assert.Equal(t, 4, counter)
 }
+
+func TestBuilderWithFuncion(t *testing.T) {
+	t.Parallel()
+
+	counter := 0
+
+	o := builder.Build(
+		builder.WithFunction(func() builder.Option[testBuildableObject] {
+			counter++
+
+			return func(*testBuildableObject) error {
+				counter++
+
+				return nil
+			}
+		}),
+	)
+
+	assert.True(t, o.IsSuccess())
+	assert.Equal(t, 2, counter)
+}

--- a/tests/builder_test.go
+++ b/tests/builder_test.go
@@ -83,7 +83,7 @@ func TestWithOptions(t *testing.T) {
 		return nil
 	}
 
-	o := builder.Build(
+	o1 := builder.Build(
 		option,
 		builder.WithOptions([]builder.Option[testBuildableObject]{
 			option,
@@ -92,8 +92,21 @@ func TestWithOptions(t *testing.T) {
 		option,
 	)
 
-	assert.True(t, o.IsSuccess())
+	assert.True(t, o1.IsSuccess())
 	assert.Equal(t, 4, counter)
+
+	o2 := builder.Build(
+		option,
+		builder.WithOptions([]builder.Option[testBuildableObject]{
+			option,
+			builder.WithError[testBuildableObject](assert.AnError),
+		}),
+		option,
+	)
+
+	assert.True(t, o2.IsFailure())
+	assert.Equal(t, 6, counter)
+	assert.Equal(t, assert.AnError, o2.Error())
 }
 
 func TestBuilderFromFunction(t *testing.T) {

--- a/tests/builder_test.go
+++ b/tests/builder_test.go
@@ -40,7 +40,7 @@ func TestBuildExecutesOptions(t *testing.T) {
 func TestBuildPassThroughOptionErrors(t *testing.T) {
 	t.Parallel()
 
-	o := builder.Build(builder.Fail[testBuildableObject](assert.AnError))
+	o := builder.Build(builder.WithError[testBuildableObject](assert.AnError))
 	assert.NotNil(t, o)
 	assert.True(t, o.IsFailure())
 	assert.Equal(t, assert.AnError, o.Error())


### PR DESCRIPTION
To allow for more complex builder chains we are adding:
* `builder.FromFunction`
* `builder.FromResult`