### PR TITLE
Allow iterators to be cloned

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -1,10 +1,16 @@
 package fun
 
+import "errors"
+
 // Iterator allows you to iterate over collections.
 type Iterator[T any] interface {
 	Next() bool
 	Value() T
+	Clone() Result[Iterator[T]]
 }
+
+// ErrIteratorNotCloneable is returned by iterators that can't be cloned.
+var ErrIteratorNotCloneable = errors.New("iterator is not cloneable")
 
 // Map applies a mapper function to every element of an iterator an returns a slice.
 func Map[T, R any](iter Iterator[T], mapper func(T) R) []R {

--- a/iterator/filter.go
+++ b/iterator/filter.go
@@ -2,6 +2,7 @@ package iterator
 
 import (
 	"github.com/sagmor/fun"
+	"github.com/sagmor/fun/result"
 )
 
 type filteredIterator[T any] struct {
@@ -25,6 +26,16 @@ func (iter *filteredIterator[T]) Next() bool {
 // Value implements fun.Iterator.
 func (iter *filteredIterator[T]) Value() T {
 	return iter.iterator.Value()
+}
+
+// Clone implements fun.Iterator.
+func (iter *filteredIterator[T]) Clone() fun.Result[fun.Iterator[T]] {
+	return result.Step(
+		iter.iterator.Clone(),
+		func(cloned fun.Iterator[T]) (fun.Iterator[T], error) {
+			return WithFilter(cloned, iter.filter), nil
+		},
+	)
 }
 
 // WithFilter creates an iterator that filter values as it's called.

--- a/iterator/slice.go
+++ b/iterator/slice.go
@@ -1,7 +1,10 @@
 // Package iterator implements functions to work with fun.Iterator[T] types.
 package iterator
 
-import "github.com/sagmor/fun"
+import (
+	"github.com/sagmor/fun"
+	"github.com/sagmor/fun/result"
+)
 
 type sliceIterator[T any] struct {
 	values  []T
@@ -18,6 +21,11 @@ func (i *sliceIterator[T]) Next() bool {
 // Value implements fun.Iterator.
 func (i *sliceIterator[T]) Value() T {
 	return i.values[i.current]
+}
+
+// Clone implements fun.Iterator.
+func (i *sliceIterator[T]) Clone() fun.Result[fun.Iterator[T]] {
+	return result.Success(FromSlice[T](i.values))
 }
 
 // FromSlice builds an iterator for a slice.
@@ -43,6 +51,11 @@ func (i *revertSliceIterator[T]) Next() bool {
 // Value implements fun.Iterator.
 func (i *revertSliceIterator[T]) Value() T {
 	return i.values[i.current]
+}
+
+// Clone implements fun.Iterator.
+func (i *revertSliceIterator[T]) Clone() fun.Result[fun.Iterator[T]] {
+	return result.Success(FromRevertSlice[T](i.values))
 }
 
 // FromRevertSlice builds an iterator for a slice that iterates backwards.

--- a/iterator/transforming.go
+++ b/iterator/transforming.go
@@ -2,6 +2,7 @@ package iterator
 
 import (
 	"github.com/sagmor/fun"
+	"github.com/sagmor/fun/result"
 )
 
 type transformingIterator[From, To any] struct {
@@ -17,6 +18,16 @@ func (iter *transformingIterator[From, To]) Next() bool {
 // Value implements fun.Iterator.
 func (iter *transformingIterator[From, To]) Value() To {
 	return iter.transform(iter.iterator.Value())
+}
+
+// Clone implements fun.Iterator.
+func (iter *transformingIterator[From, To]) Clone() fun.Result[fun.Iterator[To]] {
+	return result.Step(
+		iter.iterator.Clone(),
+		func(clone fun.Iterator[From]) (fun.Iterator[To], error) {
+			return WithTransform(clone, iter.transform), nil
+		},
+	)
 }
 
 // WithTransform creates an iterator that transforms values as it's called.

--- a/promise/iterator.go
+++ b/promise/iterator.go
@@ -2,6 +2,7 @@ package promise
 
 import (
 	"github.com/sagmor/fun"
+	"github.com/sagmor/fun/result"
 )
 
 type promiseIterator[T any] struct {
@@ -26,6 +27,11 @@ func (iter *promiseIterator[T]) Next() bool {
 // Value implements fun.Iterator.
 func (iter *promiseIterator[T]) Value() fun.Result[T] {
 	return iter.promises[iter.current].Result()
+}
+
+// Clone implements fun.Iterator.
+func (*promiseIterator[T]) Clone() fun.Result[fun.Iterator[fun.Result[T]]] {
+	return result.Failure[fun.Iterator[fun.Result[T]]](fun.ErrIteratorNotCloneable)
 }
 
 // All iterates over all promises as they are resolved.

--- a/tests/iterator_test.go
+++ b/tests/iterator_test.go
@@ -37,6 +37,10 @@ func TestIteratorFromRevertSlice(t *testing.T) {
 	assert.True(t, it.Next())
 	assert.Equal(t, 2, it.Value())
 
+	cloned := it.Clone().RequireValue()
+	assert.True(t, cloned.Next())
+	assert.Equal(t, 3, cloned.Value())
+
 	assert.True(t, it.Next())
 	assert.Equal(t, 1, it.Value())
 
@@ -86,6 +90,10 @@ func TestIteratorWithTransform(t *testing.T) {
 	assert.True(t, it.Next())
 	assert.Equal(t, "2", it.Value())
 
+	cloned := it.Clone().RequireValue()
+	assert.True(t, cloned.Next())
+	assert.Equal(t, "1", cloned.Value())
+
 	assert.True(t, it.Next())
 	assert.Equal(t, "3", it.Value())
 
@@ -96,7 +104,7 @@ func TestIteratorWithFilter(t *testing.T) {
 	t.Parallel()
 
 	it := iterator.WithFilter(
-		iterator.FromSlice([]int{1, 2, 3, 4, 5}),
+		iterator.FromSlice([]int{1, 2, 3, 4, 5, 6}),
 		func(i int) bool {
 			return i%2 == 0
 		},
@@ -106,6 +114,13 @@ func TestIteratorWithFilter(t *testing.T) {
 
 	assert.True(t, it.Next())
 	assert.Equal(t, 4, it.Value())
+
+	cloned := it.Clone().RequireValue()
+	assert.True(t, cloned.Next())
+	assert.Equal(t, 2, cloned.Value())
+
+	assert.True(t, it.Next())
+	assert.Equal(t, 6, it.Value())
 
 	assert.False(t, it.Next())
 }

--- a/tests/promise_test.go
+++ b/tests/promise_test.go
@@ -102,6 +102,9 @@ func TestPromiseAll(t *testing.T) {
 	assert.True(t, all.Next())
 	assert.Equal(t, 2, all.Value().RequireValue())
 
+	cloned := all.Clone()
+	assert.Error(t, cloned.Error())
+
 	assert.True(t, all.Next())
 	assert.Equal(t, 3, all.Value().RequireValue())
 


### PR DESCRIPTION
Add `Iterator.Clone` method so iterators that support it can be cloned